### PR TITLE
Add audio/mpeg to allowed mime types for the uploaded file

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -14,7 +14,7 @@ $(function() {
     return true;
   };
 
-  var arrowTypes = ["audio/mp3", "audio/wav"];
+  var arrowTypes = ["audio/mpeg", "audio/mp3", "audio/wav"];
   var validateFileType = function(type) {
     var ret = false;
     for (var i=0; i < arrowTypes.length; i++) {


### PR DESCRIPTION
Somehow browswers started to show error when uploading *.mp3 files:

> audio/mpegのファイルタイプはサポートしておりません。可能なファイルタイプ: audio/mp3, audio/wav